### PR TITLE
test: add comprehensive test coverage for #9 and #10

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -48,7 +48,7 @@
 - Risk: API keys stored in SQLite database without encryption
 - Files: `src-tauri/src/db/mod.rs` (settings table), `src-tauri/src/commands/llm.rs`
 - Current mitigation: Keys are stored locally only; app claims "privacy-first" approach
-- Recommendations: 
+- Recommendations:
   - Use macOS Keychain or similar OS-level secure storage
   - At minimum, encrypt sensitive settings with a device-specific key
   - Consider marking the key field as "sensitive" in the database schema

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
+        "@vitest/coverage-v8": "^3.2.3",
         "jsdom": "^26.1.0",
         "typescript": "~5.8.3",
         "vite": "^7.0.4",
@@ -28,6 +29,8 @@
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
@@ -70,6 +73,8 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.4.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.10", "@biomejs/cli-darwin-x64": "2.4.10", "@biomejs/cli-linux-arm64": "2.4.10", "@biomejs/cli-linux-arm64-musl": "2.4.10", "@biomejs/cli-linux-x64": "2.4.10", "@biomejs/cli-linux-x64-musl": "2.4.10", "@biomejs/cli-win32-arm64": "2.4.10", "@biomejs/cli-win32-x64": "2.4.10" }, "bin": { "biome": "bin/biome" } }, "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w=="],
 
@@ -151,6 +156,10 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.6", "", {}, "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -160,6 +169,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
@@ -271,6 +282,8 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
+
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
     "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
@@ -295,7 +308,13 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.15", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1nfKCq9wuAZFTkA2ey/3OXXx7GzFjLdkTiFVNwlJ9WqdI706CZRIhEqjuwanjMIja+84jDLa9rcyZDPDiVkASQ=="],
+
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
@@ -307,7 +326,13 @@
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
@@ -327,7 +352,11 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.331", "", {}, "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -343,11 +372,19 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
@@ -357,9 +394,23 @@
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
 
@@ -375,7 +426,15 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -385,7 +444,13 @@
 
     "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -423,7 +488,13 @@
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -431,11 +502,23 @@
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "test-exclude": ["test-exclude@7.0.2", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^10.4.1", "minimatch": "^10.2.2" } }, "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -477,7 +560,13 @@
 
     "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
@@ -489,10 +578,38 @@
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "make-dir/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -13,15 +13,24 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
         "@tauri-apps/cli": "^2",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
+        "jsdom": "^26.1.0",
         "typescript": "~5.8.3",
         "vite": "^7.0.4",
+        "vitest": "^3.2.3",
       },
     },
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
@@ -54,6 +63,8 @@
 
     "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
 
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
@@ -77,6 +88,16 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.1.0", "", { "dependencies": { "@csstools/color-helpers": "^5.1.0", "@csstools/css-calc": "^2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -220,6 +241,16 @@
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -227,6 +258,10 @@
     "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -236,23 +271,75 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.15", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1nfKCq9wuAZFTkA2ey/3OXXx7GzFjLdkTiFVNwlJ9WqdI706CZRIhEqjuwanjMIja+84jDLa9rcyZDPDiVkASQ=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001785", "", {}, "sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.331", "", {}, "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -260,13 +347,35 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -274,27 +383,79 @@
 
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
 
+    "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
+
+    "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
@@ -302,6 +463,36 @@
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@testing-library/react": "^16.3.0",
 		"@testing-library/user-event": "^14.6.1",
 		"@types/react": "^19.1.8",
+		"@vitest/coverage-v8": "^3.2.3",
 		"@types/react-dom": "^19.1.6",
 		"@vitejs/plugin-react": "^4.6.0",
 		"jsdom": "^26.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
 		"preview": "vite preview",
 		"typecheck": "tsc --noEmit",
 		"lint": "biome check .",
-		"tauri": "tauri"
+		"tauri": "tauri",
+		"test": "vitest",
+		"test:run": "vitest run"
 	},
 	"dependencies": {
 		"react": "^19.1.0",
@@ -20,10 +22,15 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.10",
 		"@tauri-apps/cli": "^2",
+		"@testing-library/jest-dom": "^6.6.3",
+		"@testing-library/react": "^16.3.0",
+		"@testing-library/user-event": "^14.6.1",
 		"@types/react": "^19.1.8",
 		"@types/react-dom": "^19.1.6",
 		"@vitejs/plugin-react": "^4.6.0",
+		"jsdom": "^26.1.0",
 		"typescript": "~5.8.3",
-		"vite": "^7.0.4"
+		"vite": "^7.0.4",
+		"vitest": "^3.2.3"
 	}
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1074,6 +1074,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tokio",
  "url",
+ "uuid",
  "whisper-rs",
 ]
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1073,6 +1073,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-opener",
  "tokio",
+ "url",
  "whisper-rs",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,3 +33,4 @@ reqwest = { version = "0.12", features = ["stream", "json"] }
 futures-util = "0.3"
 whisper-rs = "0.13"
 url = "2"
+uuid = { version = "1", features = ["v4"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 mod audio;
 mod commands;
-mod db;
+pub mod db;
 mod llm;
 mod system_audio;
 mod whisper;

--- a/src-tauri/tests/common/mod.rs
+++ b/src-tauri/tests/common/mod.rs
@@ -1,0 +1,73 @@
+use echo_note_lib::db::*;
+use sqlx::{Pool, Sqlite};
+use std::str::FromStr;
+
+/// Create a temporary test database pool
+pub async fn setup_test_db() -> Pool<Sqlite> {
+    // Use in-memory SQLite for fast tests
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            sqlx::sqlite::SqliteConnectOptions::from_str("sqlite::memory:")
+                .unwrap()
+                .create_if_missing(true)
+                .foreign_keys(true),
+        )
+        .await
+        .expect("Failed to create test database pool");
+
+    // Run migrations - relative to tests/ directory, migrations is at src-tauri/migrations/
+    // Tests run from src-tauri/ so we use ./migrations
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+/// Helper to create a test meeting
+pub async fn create_test_meeting(pool: &Pool<Sqlite>, title: &str) -> i64 {
+    let input = CreateMeetingInput {
+        title: title.to_string(),
+        date: chrono::Utc::now(),
+        duration_seconds: 300,
+        audio_path: "/test/audio.wav".to_string(),
+    };
+
+    create_meeting(pool, input)
+        .await
+        .expect("Failed to create test meeting")
+}
+
+/// Helper to create a test transcript
+pub async fn create_test_transcript(pool: &Pool<Sqlite>, meeting_id: i64, content: &str) -> i64 {
+    let input = CreateTranscriptInput {
+        meeting_id,
+        content: content.to_string(),
+    };
+
+    create_transcript(pool, input)
+        .await
+        .expect("Failed to create test transcript")
+}
+
+/// Helper to create a test summary
+pub async fn create_test_summary(
+    pool: &Pool<Sqlite>,
+    meeting_id: i64,
+    key_points: &str,
+    decisions: &str,
+    action_items: &str,
+) -> i64 {
+    let input = CreateSummaryInput {
+        meeting_id,
+        key_points: key_points.to_string(),
+        decisions: decisions.to_string(),
+        action_items: action_items.to_string(),
+    };
+
+    create_summary(pool, input)
+        .await
+        .expect("Failed to create test summary")
+}

--- a/src-tauri/tests/common/mod.rs
+++ b/src-tauri/tests/common/mod.rs
@@ -2,13 +2,31 @@ use echo_note_lib::db::*;
 use sqlx::{Pool, Sqlite};
 use std::str::FromStr;
 
-/// Create a temporary test database pool
+/// Create a temporary test database pool with shared in-memory database
+/// Uses a thread-local static to ensure each test thread gets its own database
+/// while allowing multiple concurrent connections within that thread
 pub async fn setup_test_db() -> Pool<Sqlite> {
-    // Use in-memory SQLite for fast tests
+    use std::cell::RefCell;
+
+    thread_local! {
+        static DB_COUNTER: RefCell<u32> = const { RefCell::new(0) };
+    }
+
+    // Generate a unique name for this test's database (per-thread isolation)
+    let db_id = DB_COUNTER.with(|c| {
+        let mut counter = c.borrow_mut();
+        *counter += 1;
+        *counter
+    });
+
+    // Use shared cache in-memory database with unique name per test instance
+    // This allows multiple connections to share the same database
+    let url = format!("file:test_db_{}?mode=memory&cache=shared", db_id);
+
     let pool = sqlx::sqlite::SqlitePoolOptions::new()
-        .max_connections(1)
+        .max_connections(5)
         .connect_with(
-            sqlx::sqlite::SqliteConnectOptions::from_str("sqlite::memory:")
+            sqlx::sqlite::SqliteConnectOptions::from_str(&url)
                 .unwrap()
                 .create_if_missing(true)
                 .foreign_keys(true),
@@ -16,8 +34,7 @@ pub async fn setup_test_db() -> Pool<Sqlite> {
         .await
         .expect("Failed to create test database pool");
 
-    // Run migrations - relative to tests/ directory, migrations is at src-tauri/migrations/
-    // Tests run from src-tauri/ so we use ./migrations
+    // Run migrations
     sqlx::migrate!("./migrations")
         .run(&pool)
         .await

--- a/src-tauri/tests/common/mod.rs
+++ b/src-tauri/tests/common/mod.rs
@@ -3,21 +3,11 @@ use sqlx::{Pool, Sqlite};
 use std::str::FromStr;
 
 /// Create a temporary test database pool with shared in-memory database
-/// Uses a thread-local static to ensure each test thread gets its own database
-/// while allowing multiple concurrent connections within that thread
+/// Uses a unique UUID for each test to ensure complete isolation
+/// while allowing multiple concurrent connections within that test
 pub async fn setup_test_db() -> Pool<Sqlite> {
-    use std::cell::RefCell;
-
-    thread_local! {
-        static DB_COUNTER: RefCell<u32> = const { RefCell::new(0) };
-    }
-
-    // Generate a unique name for this test's database (per-thread isolation)
-    let db_id = DB_COUNTER.with(|c| {
-        let mut counter = c.borrow_mut();
-        *counter += 1;
-        *counter
-    });
+    // Generate a unique database name using UUID for guaranteed uniqueness
+    let db_id = uuid::Uuid::new_v4();
 
     // Use shared cache in-memory database with unique name per test instance
     // This allows multiple connections to share the same database

--- a/src-tauri/tests/db_integration.rs
+++ b/src-tauri/tests/db_integration.rs
@@ -1,0 +1,288 @@
+use echo_note_lib::db::*;
+
+mod common;
+use common::*;
+
+#[tokio::test]
+async fn test_create_meeting() {
+    let pool = setup_test_db().await;
+
+    let input = CreateMeetingInput {
+        title: "Test Meeting".to_string(),
+        date: chrono::Utc::now(),
+        duration_seconds: 600,
+        audio_path: "/test/recording.wav".to_string(),
+    };
+
+    let id = create_meeting(&pool, input)
+        .await
+        .expect("Failed to create meeting");
+    assert!(id > 0);
+
+    // Verify the meeting was created
+    let meeting = get_meeting(&pool, id).await.expect("Failed to get meeting");
+    assert!(meeting.is_some());
+    let meeting = meeting.unwrap();
+    assert_eq!(meeting.title, "Test Meeting");
+    assert_eq!(meeting.duration_seconds, 600);
+}
+
+#[tokio::test]
+async fn test_list_meetings() {
+    let pool = setup_test_db().await;
+
+    // Create multiple meetings
+    let id1 = create_test_meeting(&pool, "Meeting 1").await;
+    let id2 = create_test_meeting(&pool, "Meeting 2").await;
+    let id3 = create_test_meeting(&pool, "Meeting 3").await;
+
+    let meetings = list_meetings(&pool).await.expect("Failed to list meetings");
+    assert_eq!(meetings.len(), 3);
+
+    // Verify IDs are present
+    let ids: Vec<i64> = meetings.iter().map(|m| m.id).collect();
+    assert!(ids.contains(&id1));
+    assert!(ids.contains(&id2));
+    assert!(ids.contains(&id3));
+}
+
+#[tokio::test]
+async fn test_update_meeting() {
+    let pool = setup_test_db().await;
+
+    let id = create_test_meeting(&pool, "Original Title").await;
+
+    // Update the meeting
+    let updated = update_meeting(&pool, id, "Updated Title".to_string())
+        .await
+        .expect("Failed to update meeting");
+    assert!(updated);
+
+    // Verify the update
+    let meeting = get_meeting(&pool, id)
+        .await
+        .expect("Failed to get meeting")
+        .unwrap();
+    assert_eq!(meeting.title, "Updated Title");
+}
+
+#[tokio::test]
+async fn test_delete_meeting() {
+    let pool = setup_test_db().await;
+
+    let id = create_test_meeting(&pool, "Meeting to Delete").await;
+
+    // Verify meeting exists
+    let meeting = get_meeting(&pool, id).await.expect("Failed to get meeting");
+    assert!(meeting.is_some());
+
+    // Delete the meeting
+    let deleted = delete_meeting(&pool, id)
+        .await
+        .expect("Failed to delete meeting");
+    assert!(deleted);
+
+    // Verify meeting is gone
+    let meeting = get_meeting(&pool, id).await.expect("Failed to get meeting");
+    assert!(meeting.is_none());
+}
+
+#[tokio::test]
+async fn test_create_transcript() {
+    let pool = setup_test_db().await;
+
+    let meeting_id = create_test_meeting(&pool, "Test Meeting").await;
+
+    let input = CreateTranscriptInput {
+        meeting_id,
+        content: "This is a test transcript.".to_string(),
+    };
+
+    let id = create_transcript(&pool, input)
+        .await
+        .expect("Failed to create transcript");
+    assert!(id > 0);
+
+    // Verify the transcript was created
+    let transcript = get_transcript(&pool, id)
+        .await
+        .expect("Failed to get transcript");
+    assert!(transcript.is_some());
+    let transcript = transcript.unwrap();
+    assert_eq!(transcript.content, "This is a test transcript.");
+    assert_eq!(transcript.meeting_id, meeting_id);
+}
+
+#[tokio::test]
+async fn test_get_transcript_by_meeting() {
+    let pool = setup_test_db().await;
+
+    let meeting_id = create_test_meeting(&pool, "Test Meeting").await;
+    let _transcript_id = create_test_transcript(&pool, meeting_id, "Test content").await;
+
+    let transcript = get_transcript_by_meeting(&pool, meeting_id)
+        .await
+        .expect("Failed to get transcript by meeting")
+        .expect("Transcript not found");
+
+    assert_eq!(transcript.content, "Test content");
+}
+
+#[tokio::test]
+async fn test_create_summary() {
+    let pool = setup_test_db().await;
+
+    let meeting_id = create_test_meeting(&pool, "Test Meeting").await;
+
+    let input = CreateSummaryInput {
+        meeting_id,
+        key_points: "- Point 1\n- Point 2".to_string(),
+        decisions: "- Decision 1".to_string(),
+        action_items: "- Action 1".to_string(),
+    };
+
+    let id = create_summary(&pool, input)
+        .await
+        .expect("Failed to create summary");
+    assert!(id > 0);
+
+    // Verify the summary was created
+    let summary = get_summary(&pool, id).await.expect("Failed to get summary");
+    assert!(summary.is_some());
+    let summary = summary.unwrap();
+    assert!(summary.key_points.contains("Point 1"));
+    assert!(summary.decisions.contains("Decision 1"));
+    assert!(summary.action_items.contains("Action 1"));
+}
+
+#[tokio::test]
+async fn test_get_summary_by_meeting() {
+    let pool = setup_test_db().await;
+
+    let meeting_id = create_test_meeting(&pool, "Test Meeting").await;
+    let _summary_id = create_test_summary(
+        &pool,
+        meeting_id,
+        "- Key point",
+        "- Decision",
+        "- Action item",
+    )
+    .await;
+
+    let summary = get_summary_by_meeting(&pool, meeting_id)
+        .await
+        .expect("Failed to get summary by meeting")
+        .expect("Summary not found");
+
+    assert!(summary.key_points.contains("Key point"));
+}
+
+#[tokio::test]
+async fn test_settings_crud() {
+    let pool = setup_test_db().await;
+
+    // Create a setting
+    let created = set_setting(&pool, "test_key", "test_value")
+        .await
+        .expect("Failed to set setting");
+    assert!(created);
+
+    // Read the setting (with default value in case not found)
+    let value = get_setting(&pool, "test_key", "default")
+        .await
+        .expect("Failed to get setting");
+    assert_eq!(value, "test_value".to_string());
+
+    // Update the setting
+    let updated = set_setting(&pool, "test_key", "updated_value")
+        .await
+        .expect("Failed to update setting");
+    assert!(updated);
+
+    let value = get_setting(&pool, "test_key", "default")
+        .await
+        .expect("Failed to get setting");
+    assert_eq!(value, "updated_value".to_string());
+
+    // Delete the setting
+    let deleted = delete_setting(&pool, "test_key")
+        .await
+        .expect("Failed to delete setting");
+    assert!(deleted);
+
+    // After deletion, should return default value
+    let value = get_setting(&pool, "test_key", "default")
+        .await
+        .expect("Failed to get setting");
+    assert_eq!(value, "default".to_string());
+}
+
+#[tokio::test]
+async fn test_list_settings() {
+    let pool = setup_test_db().await;
+
+    // Create multiple settings
+    set_setting(&pool, "key1", "value1").await.unwrap();
+    set_setting(&pool, "key2", "value2").await.unwrap();
+    set_setting(&pool, "key3", "value3").await.unwrap();
+
+    let settings = list_settings(&pool).await.expect("Failed to list settings");
+    assert_eq!(settings.len(), 3);
+}
+
+#[tokio::test]
+async fn test_cascade_delete_meeting_deletes_transcript() {
+    let pool = setup_test_db().await;
+
+    let meeting_id = create_test_meeting(&pool, "Test Meeting").await;
+    let transcript_id = create_test_transcript(&pool, meeting_id, "Test content").await;
+
+    // Verify transcript exists
+    let transcript = get_transcript(&pool, transcript_id)
+        .await
+        .expect("Failed to get transcript");
+    assert!(transcript.is_some());
+
+    // Delete the meeting
+    delete_meeting(&pool, meeting_id)
+        .await
+        .expect("Failed to delete meeting");
+
+    // Verify transcript is also deleted (cascade)
+    let transcript = get_transcript(&pool, transcript_id)
+        .await
+        .expect("Failed to get transcript");
+    assert!(transcript.is_none());
+}
+
+#[tokio::test]
+async fn test_update_nonexistent_meeting() {
+    let pool = setup_test_db().await;
+
+    // Try to update a meeting that doesn't exist
+    let updated = update_meeting(&pool, 9999, "New Title".to_string())
+        .await
+        .expect("Failed to update meeting");
+    assert!(!updated);
+}
+
+#[tokio::test]
+async fn test_delete_nonexistent_meeting() {
+    let pool = setup_test_db().await;
+
+    // Try to delete a meeting that doesn't exist
+    let deleted = delete_meeting(&pool, 9999)
+        .await
+        .expect("Failed to delete meeting");
+    assert!(!deleted);
+}
+
+#[tokio::test]
+async fn test_get_nonexistent_meeting() {
+    let pool = setup_test_db().await;
+
+    let meeting = get_meeting(&pool, 9999)
+        .await
+        .expect("Failed to get meeting");
+    assert!(meeting.is_none());
+}

--- a/src-tauri/tests/meeting_flow.rs
+++ b/src-tauri/tests/meeting_flow.rs
@@ -1,0 +1,311 @@
+use echo_note_lib::db::*;
+
+mod common;
+use common::*;
+
+/// Test the full meeting lifecycle: create → transcribe → summarize → delete
+#[tokio::test]
+async fn test_full_meeting_lifecycle() {
+    let pool = setup_test_db().await;
+
+    // 1. Create a meeting
+    let meeting_input = CreateMeetingInput {
+        title: "Quarterly Planning".to_string(),
+        date: chrono::Utc::now(),
+        duration_seconds: 3600,
+        audio_path: "/recordings/quarterly_planning.wav".to_string(),
+    };
+
+    let meeting_id = create_meeting(&pool, meeting_input)
+        .await
+        .expect("Failed to create meeting");
+    assert!(meeting_id > 0, "Meeting ID should be positive");
+
+    // Verify meeting exists
+    let meeting = get_meeting(&pool, meeting_id)
+        .await
+        .expect("Failed to get meeting")
+        .expect("Meeting should exist");
+    assert_eq!(meeting.title, "Quarterly Planning");
+
+    // 2. Create a transcript for the meeting
+    let transcript_input = CreateTranscriptInput {
+        meeting_id,
+        content: "We discussed Q3 goals and set targets for the team.".to_string(),
+    };
+
+    let transcript_id = create_transcript(&pool, transcript_input)
+        .await
+        .expect("Failed to create transcript");
+    assert!(transcript_id > 0);
+
+    // Verify transcript exists and is linked to meeting
+    let transcript = get_transcript_by_meeting(&pool, meeting_id)
+        .await
+        .expect("Failed to get transcript")
+        .expect("Transcript should exist");
+    assert_eq!(
+        transcript.content,
+        "We discussed Q3 goals and set targets for the team."
+    );
+
+    // 3. Create a summary for the meeting
+    let summary_input = CreateSummaryInput {
+        meeting_id,
+        key_points: "- Q3 revenue target: $1M\n- Launch mobile app".to_string(),
+        decisions: "- Approved Q3 budget\n- Hired 2 developers".to_string(),
+        action_items: "- John: Prepare roadmap\n- Sarah: Update team".to_string(),
+    };
+
+    let summary_id = create_summary(&pool, summary_input)
+        .await
+        .expect("Failed to create summary");
+    assert!(summary_id > 0);
+
+    // Verify summary exists and is linked to meeting
+    let summary = get_summary_by_meeting(&pool, meeting_id)
+        .await
+        .expect("Failed to get summary")
+        .expect("Summary should exist");
+    assert!(summary.key_points.contains("$1M"));
+    assert!(summary.decisions.contains("Approved Q3 budget"));
+
+    // 4. Delete the meeting (should cascade to transcript and summary)
+    let deleted = delete_meeting(&pool, meeting_id)
+        .await
+        .expect("Failed to delete meeting");
+    assert!(deleted, "Meeting should be deleted");
+
+    // Verify all related records are deleted
+    let meeting = get_meeting(&pool, meeting_id)
+        .await
+        .expect("Failed to get meeting");
+    assert!(meeting.is_none(), "Meeting should be deleted");
+
+    let transcript = get_transcript(&pool, transcript_id)
+        .await
+        .expect("Failed to get transcript");
+    assert!(
+        transcript.is_none(),
+        "Transcript should be deleted via cascade"
+    );
+
+    let summary = get_summary(&pool, summary_id)
+        .await
+        .expect("Failed to get summary");
+    assert!(summary.is_none(), "Summary should be deleted via cascade");
+}
+
+/// Test meeting with empty transcript content (edge case)
+#[tokio::test]
+async fn test_meeting_with_empty_transcript() {
+    let pool = setup_test_db().await;
+
+    let meeting_id = create_test_meeting(&pool, "Empty Transcript Meeting").await;
+
+    // Create transcript with empty content
+    let input = CreateTranscriptInput {
+        meeting_id,
+        content: "".to_string(),
+    };
+
+    let transcript_id = create_transcript(&pool, input)
+        .await
+        .expect("Should create empty transcript");
+
+    let transcript = get_transcript(&pool, transcript_id).await.unwrap().unwrap();
+    assert_eq!(transcript.content, "");
+}
+
+/// Test duplicate meeting titles are allowed
+#[tokio::test]
+async fn test_duplicate_meeting_titles() {
+    let pool = setup_test_db().await;
+
+    // Create two meetings with the same title
+    let id1 = create_test_meeting(&pool, "Weekly Standup").await;
+    let id2 = create_test_meeting(&pool, "Weekly Standup").await;
+
+    // Both should be created with different IDs
+    assert_ne!(id1, id2, "Meetings should have different IDs");
+
+    let meetings = list_meetings(&pool).await.expect("Failed to list meetings");
+    assert_eq!(meetings.len(), 2);
+
+    // Both should exist with same title
+    let meeting1 = get_meeting(&pool, id1).await.unwrap().unwrap();
+    let meeting2 = get_meeting(&pool, id2).await.unwrap().unwrap();
+    assert_eq!(meeting1.title, "Weekly Standup");
+    assert_eq!(meeting2.title, "Weekly Standup");
+}
+
+/// Test updating meeting with transcript and summary intact
+#[tokio::test]
+async fn test_update_meeting_preserves_related_data() {
+    let pool = setup_test_db().await;
+
+    // Create full meeting data
+    let meeting_id = create_test_meeting(&pool, "Original Title").await;
+    let transcript_id = create_test_transcript(&pool, meeting_id, "Original content").await;
+    let summary_id = create_test_summary(&pool, meeting_id, "Original key points", "", "").await;
+
+    // Update only the meeting title
+    let updated = update_meeting(&pool, meeting_id, "Updated Title".to_string())
+        .await
+        .expect("Failed to update meeting");
+    assert!(updated);
+
+    // Verify meeting title changed
+    let meeting = get_meeting(&pool, meeting_id).await.unwrap().unwrap();
+    assert_eq!(meeting.title, "Updated Title");
+
+    // Verify transcript and summary are unchanged
+    let transcript = get_transcript(&pool, transcript_id).await.unwrap().unwrap();
+    assert_eq!(transcript.content, "Original content");
+
+    let summary = get_summary(&pool, summary_id).await.unwrap().unwrap();
+    assert!(summary.key_points.contains("Original key points"));
+}
+
+/// Test listing meetings returns them in correct order (newest first)
+#[tokio::test]
+async fn test_meetings_sorted_by_date() {
+    let pool = setup_test_db().await;
+
+    // Create meetings with specific dates
+    let input1 = CreateMeetingInput {
+        title: "Old Meeting".to_string(),
+        date: chrono::DateTime::parse_from_rfc3339("2026-01-01T10:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+        duration_seconds: 300,
+        audio_path: "/test/old.wav".to_string(),
+    };
+
+    let input2 = CreateMeetingInput {
+        title: "New Meeting".to_string(),
+        date: chrono::DateTime::parse_from_rfc3339("2026-12-31T10:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+        duration_seconds: 300,
+        audio_path: "/test/new.wav".to_string(),
+    };
+
+    let id1 = create_meeting(&pool, input1).await.unwrap();
+    let id2 = create_meeting(&pool, input2).await.unwrap();
+
+    // List meetings - should be sorted by date (newest first)
+    let meetings = list_meetings(&pool).await.unwrap();
+    assert_eq!(meetings.len(), 2);
+    assert_eq!(meetings[0].id, id2, "Newer meeting should be first");
+    assert_eq!(meetings[1].id, id1, "Older meeting should be second");
+}
+
+/// Test multiple transcripts can exist for the same meeting
+#[tokio::test]
+async fn test_multiple_transcripts_per_meeting() {
+    let pool = setup_test_db().await;
+
+    let meeting_id = create_test_meeting(&pool, "Test Meeting").await;
+
+    // Create first transcript
+    let input1 = CreateTranscriptInput {
+        meeting_id,
+        content: "First transcript".to_string(),
+    };
+    let id1 = create_transcript(&pool, input1).await.unwrap();
+
+    // Create second transcript for same meeting
+    let input2 = CreateTranscriptInput {
+        meeting_id,
+        content: "Second transcript".to_string(),
+    };
+    let id2 = create_transcript(&pool, input2).await.unwrap();
+
+    // Verify both transcripts exist
+    assert_ne!(id1, id2);
+    let transcripts = list_transcripts(&pool).await.unwrap();
+    assert_eq!(transcripts.len(), 2);
+}
+
+/// Test deleting transcript without affecting meeting
+#[tokio::test]
+async fn test_delete_transcript_preserves_meeting() {
+    let pool = setup_test_db().await;
+
+    let meeting_id = create_test_meeting(&pool, "Test Meeting").await;
+    let transcript_id = create_test_transcript(&pool, meeting_id, "Test content").await;
+
+    // Delete only the transcript
+    let deleted = delete_transcript(&pool, transcript_id)
+        .await
+        .expect("Failed to delete transcript");
+    assert!(deleted);
+
+    // Meeting should still exist
+    let meeting = get_meeting(&pool, meeting_id).await.unwrap();
+    assert!(
+        meeting.is_some(),
+        "Meeting should still exist after transcript deletion"
+    );
+
+    // Transcript should be gone
+    let transcript = get_transcript(&pool, transcript_id).await.unwrap();
+    assert!(transcript.is_none());
+}
+
+/// Test deleting summary without affecting meeting
+#[tokio::test]
+async fn test_delete_summary_preserves_meeting() {
+    let pool = setup_test_db().await;
+
+    let meeting_id = create_test_meeting(&pool, "Test Meeting").await;
+    let summary_id =
+        create_test_summary(&pool, meeting_id, "Key points", "Decisions", "Actions").await;
+
+    // Delete only the summary
+    let deleted = delete_summary(&pool, summary_id)
+        .await
+        .expect("Failed to delete summary");
+    assert!(deleted);
+
+    // Meeting should still exist
+    let meeting = get_meeting(&pool, meeting_id).await.unwrap();
+    assert!(
+        meeting.is_some(),
+        "Meeting should still exist after summary deletion"
+    );
+
+    // Summary should be gone
+    let summary = get_summary(&pool, summary_id).await.unwrap();
+    assert!(summary.is_none());
+}
+
+/// Test multiple meetings with full data
+#[tokio::test]
+async fn test_multiple_full_meetings() {
+    let pool = setup_test_db().await;
+
+    // Create 3 complete meetings (with transcripts and summaries)
+    for i in 1..=3 {
+        let meeting_id = create_test_meeting(&pool, &format!("Meeting {}", i)).await;
+        create_test_transcript(&pool, meeting_id, &format!("Transcript {}", i)).await;
+        create_test_summary(
+            &pool,
+            meeting_id,
+            &format!("Key points {}", i),
+            &format!("Decisions {}", i),
+            &format!("Actions {}", i),
+        )
+        .await;
+    }
+
+    // Verify counts
+    let meetings = list_meetings(&pool).await.unwrap();
+    let transcripts = list_transcripts(&pool).await.unwrap();
+    let summaries = list_summaries(&pool).await.unwrap();
+
+    assert_eq!(meetings.len(), 3);
+    assert_eq!(transcripts.len(), 3);
+    assert_eq!(summaries.len(), 3);
+}

--- a/src/components/MeetingDetailView.tsx
+++ b/src/components/MeetingDetailView.tsx
@@ -275,6 +275,7 @@ export function MeetingDetailView({ meetingId, onBack }: MeetingDetailViewProps)
 									className="title-edit-button save"
 									onClick={handleTitleSave}
 									disabled={isSavingTitle}
+									aria-label="Save title"
 								>
 									✓
 								</button>
@@ -283,6 +284,7 @@ export function MeetingDetailView({ meetingId, onBack }: MeetingDetailViewProps)
 									className="title-edit-button cancel"
 									onClick={handleTitleCancel}
 									disabled={isSavingTitle}
+									aria-label="Cancel editing"
 								>
 									✕
 								</button>
@@ -324,6 +326,7 @@ export function MeetingDetailView({ meetingId, onBack }: MeetingDetailViewProps)
 											"summary",
 										)
 									}
+									aria-label="Copy summary"
 								>
 									{copiedSection === "summary" ? "✓ Copied" : "📋 Copy"}
 								</button>
@@ -390,6 +393,7 @@ export function MeetingDetailView({ meetingId, onBack }: MeetingDetailViewProps)
 									type="button"
 									className={`copy-button ${copiedSection === "transcript" ? "copied" : ""}`}
 									onClick={() => transcript && handleCopy(transcript.content, "transcript")}
+									aria-label="Copy transcript"
 								>
 									{copiedSection === "transcript" ? "✓ Copied" : "📋 Copy"}
 								</button>

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorBoundary } from "../ErrorBoundary";
+
+// Component that throws an error
+function ThrowError({ shouldThrow }: { shouldThrow: boolean }) {
+	if (shouldThrow) {
+		throw new Error("Test error");
+	}
+	return <div>No error</div>;
+}
+
+describe("ErrorBoundary", () => {
+	// Suppress console.error for expected errors
+	const originalConsoleError = console.error;
+	beforeEach(() => {
+		console.error = vi.fn();
+	});
+	afterEach(() => {
+		console.error = originalConsoleError;
+	});
+
+	it("renders children when there is no error", () => {
+		render(
+			<ErrorBoundary>
+				<div>Test content</div>
+			</ErrorBoundary>,
+		);
+
+		expect(screen.getByText("Test content")).toBeInTheDocument();
+	});
+
+	it("shows fallback UI when child throws error", () => {
+		render(
+			<ErrorBoundary>
+				<ThrowError shouldThrow={true} />
+			</ErrorBoundary>,
+		);
+
+		expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+		expect(screen.getByText("Test error")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+	});
+
+	it("shows section label in error message when section prop is provided", () => {
+		render(
+			<ErrorBoundary section="Settings Panel">
+				<ThrowError shouldThrow={true} />
+			</ErrorBoundary>,
+		);
+
+		expect(screen.getByText("Settings Panel failed to load")).toBeInTheDocument();
+	});
+
+	it("has a working try again button in error state", () => {
+		render(
+			<ErrorBoundary>
+				<ThrowError shouldThrow={true} />
+			</ErrorBoundary>,
+		);
+
+		// Find the try again button in the error fallback UI
+		const tryAgainButton = screen.getByRole("button", { name: /try again/i });
+		expect(tryAgainButton).toBeInTheDocument();
+
+		// Clicking the button should not throw an error
+		expect(() => fireEvent.click(tryAgainButton)).not.toThrow();
+	});
+});
+
+// Additional test with state recovery
+describe("ErrorBoundary with recovery", () => {
+	const originalConsoleError = console.error;
+	beforeEach(() => {
+		console.error = vi.fn();
+	});
+	afterEach(() => {
+		console.error = originalConsoleError;
+	});
+
+	it("recovers when error condition is resolved", () => {
+		function TestComponent() {
+			const [shouldThrow] = useState(true);
+
+			if (shouldThrow) {
+				return (
+					<div>
+						<ThrowError shouldThrow={true} />
+					</div>
+				);
+			}
+			return <div>Recovered successfully</div>;
+		}
+
+		// Render with separate ErrorBoundary to test recovery
+		const { rerender } = render(
+			<ErrorBoundary key="test">
+				<TestComponent />
+			</ErrorBoundary>,
+		);
+
+		expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+		// Re-render with key change simulates fresh mount
+		rerender(
+			<ErrorBoundary key="test2">
+				<div>Recovered successfully</div>
+			</ErrorBoundary>,
+		);
+
+		expect(screen.getByText("Recovered successfully")).toBeInTheDocument();
+	});
+});

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -67,48 +67,39 @@ describe("ErrorBoundary", () => {
 		// Clicking the button should not throw an error
 		expect(() => fireEvent.click(tryAgainButton)).not.toThrow();
 	});
-});
 
-// Additional test with state recovery
-describe("ErrorBoundary with recovery", () => {
-	const originalConsoleError = console.error;
-	beforeEach(() => {
-		console.error = vi.fn();
-	});
-	afterEach(() => {
-		console.error = originalConsoleError;
-	});
+	describe("with recovery", () => {
+		it("recovers when error condition is resolved", () => {
+			function TestComponent() {
+				const [shouldThrow] = useState(true);
 
-	it("recovers when error condition is resolved", () => {
-		function TestComponent() {
-			const [shouldThrow] = useState(true);
-
-			if (shouldThrow) {
-				return (
-					<div>
-						<ThrowError shouldThrow={true} />
-					</div>
-				);
+				if (shouldThrow) {
+					return (
+						<div>
+							<ThrowError shouldThrow={true} />
+						</div>
+					);
+				}
+				return <div>Recovered successfully</div>;
 			}
-			return <div>Recovered successfully</div>;
-		}
 
-		// Render with separate ErrorBoundary to test recovery
-		const { rerender } = render(
-			<ErrorBoundary key="test">
-				<TestComponent />
-			</ErrorBoundary>,
-		);
+			// Render with separate ErrorBoundary to test recovery
+			const { rerender } = render(
+				<ErrorBoundary key="test">
+					<TestComponent />
+				</ErrorBoundary>,
+			);
 
-		expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+			expect(screen.getByText("Something went wrong")).toBeInTheDocument();
 
-		// Re-render with key change simulates fresh mount
-		rerender(
-			<ErrorBoundary key="test2">
-				<div>Recovered successfully</div>
-			</ErrorBoundary>,
-		);
+			// Re-render with key change simulates fresh mount
+			rerender(
+				<ErrorBoundary key="test2">
+					<div>Recovered successfully</div>
+				</ErrorBoundary>,
+			);
 
-		expect(screen.getByText("Recovered successfully")).toBeInTheDocument();
+			expect(screen.getByText("Recovered successfully")).toBeInTheDocument();
+		});
 	});
 });

--- a/src/components/__tests__/HistoryView.test.tsx
+++ b/src/components/__tests__/HistoryView.test.tsx
@@ -1,0 +1,218 @@
+import { invoke } from "@tauri-apps/api/core";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HistoryView } from "../HistoryView";
+
+// Mock Tauri API
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: vi.fn(),
+}));
+
+const mockMeetings = [
+	{
+		id: 1,
+		title: "Team Standup",
+		date: "2026-04-20T10:00:00Z",
+		duration_seconds: 900,
+		audio_path: "/path/to/audio1.wav",
+		created_at: "2026-04-20T10:00:00Z",
+	},
+	{
+		id: 2,
+		title: "Product Review",
+		date: "2026-04-19T14:30:00Z",
+		duration_seconds: 1800,
+		audio_path: "/path/to/audio2.wav",
+		created_at: "2026-04-19T14:30:00Z",
+	},
+];
+
+describe("HistoryView", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("shows loading state initially", () => {
+		vi.mocked(invoke).mockImplementation(() => new Promise(() => {}));
+
+		render(<HistoryView />);
+
+		expect(screen.getByText("Loading meetings...")).toBeInTheDocument();
+	});
+
+	it("displays meetings list after loading", async () => {
+		vi.mocked(invoke).mockResolvedValue({
+			success: true,
+			data: mockMeetings,
+			error: null,
+		});
+
+		render(<HistoryView />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Team Standup")).toBeInTheDocument();
+		});
+
+		expect(screen.getByText("Product Review")).toBeInTheDocument();
+		expect(screen.getByText("2 meetings recorded")).toBeInTheDocument();
+	});
+
+	it("shows empty state when no meetings exist", async () => {
+		vi.mocked(invoke).mockResolvedValue({
+			success: true,
+			data: [],
+			error: null,
+		});
+
+		render(<HistoryView />);
+
+		await waitFor(() => {
+			expect(screen.getByText("No meetings yet")).toBeInTheDocument();
+		});
+
+		expect(screen.getByText("Record your first meeting to see it here.")).toBeInTheDocument();
+	});
+
+	it("shows error state when API fails", async () => {
+		vi.mocked(invoke).mockResolvedValue({
+			success: false,
+			data: null,
+			error: "Failed to connect to database",
+		});
+
+		render(<HistoryView />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Failed to connect to database")).toBeInTheDocument();
+		});
+
+		expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+	});
+
+	it("calls onMeetingClick when meeting is clicked", async () => {
+		const onMeetingClick = vi.fn();
+		vi.mocked(invoke).mockResolvedValue({
+			success: true,
+			data: mockMeetings,
+			error: null,
+		});
+
+		render(<HistoryView onMeetingClick={onMeetingClick} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Team Standup")).toBeInTheDocument();
+		});
+
+		const meetingItem = screen.getByText("Team Standup").closest("[role='button']");
+		if (!meetingItem) throw new Error("Meeting item not found");
+		await userEvent.click(meetingItem);
+
+		expect(onMeetingClick).toHaveBeenCalledWith(1);
+	});
+
+	it("shows delete confirmation modal when delete is clicked", async () => {
+		vi.mocked(invoke).mockResolvedValue({
+			success: true,
+			data: mockMeetings,
+			error: null,
+		});
+
+		render(<HistoryView />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Team Standup")).toBeInTheDocument();
+		});
+
+		const deleteButton = screen.getByLabelText("Delete Team Standup");
+		await userEvent.click(deleteButton);
+
+		expect(screen.getByText("Delete Meeting?")).toBeInTheDocument();
+		expect(screen.getByText(/Are you sure you want to delete this meeting/i)).toBeInTheDocument();
+	});
+
+	it("cancels delete when cancel button is clicked", async () => {
+		vi.mocked(invoke).mockResolvedValue({
+			success: true,
+			data: mockMeetings,
+			error: null,
+		});
+
+		render(<HistoryView />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Team Standup")).toBeInTheDocument();
+		});
+
+		const deleteButton = screen.getByLabelText("Delete Team Standup");
+		await userEvent.click(deleteButton);
+
+		const cancelButton = screen.getByRole("button", { name: /cancel/i });
+		await userEvent.click(cancelButton);
+
+		await waitFor(() => {
+			expect(screen.queryByText("Delete Meeting?")).not.toBeInTheDocument();
+		});
+
+		// Meeting should still be visible
+		expect(screen.getByText("Team Standup")).toBeInTheDocument();
+	});
+
+	it("deletes meeting when confirm is clicked", async () => {
+		const onDeleteMeeting = vi.fn();
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			if (command === "list_meetings_command") {
+				return { success: true, data: mockMeetings, error: null };
+			}
+			if (command === "delete_meeting_command") {
+				return { success: true, data: true, error: null };
+			}
+			return { success: false, data: null, error: "Unknown command" };
+		});
+
+		render(<HistoryView onDeleteMeeting={onDeleteMeeting} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Team Standup")).toBeInTheDocument();
+		});
+
+		const deleteButton = screen.getByLabelText("Delete Team Standup");
+		await userEvent.click(deleteButton);
+
+		// Look for the danger/delete button in the modal (more specific selector)
+		const confirmButton = screen.getByRole("button", { name: /^delete$/i });
+		await userEvent.click(confirmButton);
+
+		await waitFor(() => {
+			expect(onDeleteMeeting).toHaveBeenCalledWith(1);
+		});
+	});
+
+	it("retries loading when retry button is clicked", async () => {
+		vi.mocked(invoke).mockResolvedValueOnce({
+			success: false,
+			data: null,
+			error: "Network error",
+		});
+
+		render(<HistoryView />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Network error")).toBeInTheDocument();
+		});
+
+		// Setup success for retry
+		vi.mocked(invoke).mockResolvedValueOnce({
+			success: true,
+			data: mockMeetings,
+			error: null,
+		});
+
+		const retryButton = screen.getByRole("button", { name: /retry/i });
+		await userEvent.click(retryButton);
+
+		await waitFor(() => {
+			expect(screen.getByText("Team Standup")).toBeInTheDocument();
+		});
+	});
+});

--- a/src/components/__tests__/HistoryView.test.tsx
+++ b/src/components/__tests__/HistoryView.test.tsx
@@ -99,8 +99,8 @@ describe("HistoryView", () => {
 			expect(screen.getByText("Team Standup")).toBeInTheDocument();
 		});
 
-		const meetingItem = screen.getByText("Team Standup").closest("[role='button']");
-		if (!meetingItem) throw new Error("Meeting item not found");
+		// Find the meeting item by role and name for resilience
+		const meetingItem = screen.getByRole("button", { name: /team standup/i });
 		await userEvent.click(meetingItem);
 
 		expect(onMeetingClick).toHaveBeenCalledWith(1);

--- a/src/components/__tests__/HistoryView.test.tsx
+++ b/src/components/__tests__/HistoryView.test.tsx
@@ -4,11 +4,6 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HistoryView } from "../HistoryView";
 
-// Mock Tauri API
-vi.mock("@tauri-apps/api/core", () => ({
-	invoke: vi.fn(),
-}));
-
 const mockMeetings = [
 	{
 		id: 1,

--- a/src/components/__tests__/MeetingDetailView.test.tsx
+++ b/src/components/__tests__/MeetingDetailView.test.tsx
@@ -1,0 +1,389 @@
+import { invoke } from "@tauri-apps/api/core";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MeetingDetailView } from "../MeetingDetailView";
+
+// Mock Tauri API
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: vi.fn(),
+}));
+
+const mockMeeting = {
+	id: 1,
+	title: "Product Planning Meeting",
+	date: "2026-04-20T10:00:00Z",
+	duration_seconds: 1800,
+	audio_path: "/path/to/audio.wav",
+	created_at: "2026-04-20T10:00:00Z",
+};
+
+const mockTranscript = {
+	id: 1,
+	meeting_id: 1,
+	content: "We discussed the roadmap for Q2 and decided to prioritize the mobile app.",
+	created_at: "2026-04-20T10:05:00Z",
+};
+
+const mockSummary = {
+	id: 1,
+	meeting_id: 1,
+	key_points: "- Discussed Q2 roadmap\n- Mobile app is top priority\n- Need more resources",
+	decisions: "- Approved Q2 plan\n- Hired 2 more developers",
+	action_items: "- John: Prepare design mockups\n- Sarah: Schedule follow-up",
+	created_at: "2026-04-20T10:10:00Z",
+};
+
+describe("MeetingDetailView", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("shows loading state initially", () => {
+		vi.mocked(invoke).mockImplementation(() => new Promise(() => {}));
+
+		render(<MeetingDetailView meetingId={1} />);
+
+		expect(screen.getByText("Loading meeting details...")).toBeInTheDocument();
+	});
+
+	it("displays meeting details with transcript and summary", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "get_meeting_command":
+					return { success: true, data: mockMeeting, error: null };
+				case "get_transcript_by_meeting_command":
+					return { success: true, data: mockTranscript, error: null };
+				case "get_summary_by_meeting_command":
+					return { success: true, data: mockSummary, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<MeetingDetailView meetingId={1} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Product Planning Meeting")).toBeInTheDocument();
+		});
+
+		// Check for duration format (30:00 for 1800 seconds)
+		expect(screen.getByText(/30:00/)).toBeInTheDocument();
+		expect(screen.getByText("Summary")).toBeInTheDocument();
+		expect(screen.getByText("Transcript")).toBeInTheDocument();
+	});
+
+	it("shows error when meeting not found", async () => {
+		vi.mocked(invoke).mockResolvedValue({
+			success: false,
+			data: null,
+			error: "Meeting not found",
+		});
+
+		render(<MeetingDetailView meetingId={999} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Meeting not found")).toBeInTheDocument();
+		});
+	});
+
+	it("calls onBack when back button is clicked", async () => {
+		const onBack = vi.fn();
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "get_meeting_command":
+					return { success: true, data: mockMeeting, error: null };
+				case "get_transcript_by_meeting_command":
+					return { success: true, data: null, error: null };
+				case "get_summary_by_meeting_command":
+					return { success: true, data: null, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<MeetingDetailView meetingId={1} onBack={onBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Product Planning Meeting")).toBeInTheDocument();
+		});
+
+		const backButton = screen.getByRole("button", { name: /back/i });
+		await userEvent.click(backButton);
+
+		expect(onBack).toHaveBeenCalled();
+	});
+
+	it("enters edit mode when title is clicked", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "get_meeting_command":
+					return { success: true, data: mockMeeting, error: null };
+				case "get_transcript_by_meeting_command":
+					return { success: true, data: null, error: null };
+				case "get_summary_by_meeting_command":
+					return { success: true, data: null, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<MeetingDetailView meetingId={1} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Product Planning Meeting")).toBeInTheDocument();
+		});
+
+		// Find edit button by title attribute or class
+		const editButton = screen.getByTitle("Edit title");
+		await userEvent.click(editButton);
+
+		expect(screen.getByRole("textbox")).toBeInTheDocument();
+	});
+
+	it("saves edited title when save is clicked", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "get_meeting_command":
+					return { success: true, data: mockMeeting, error: null };
+				case "get_transcript_by_meeting_command":
+					return { success: true, data: null, error: null };
+				case "get_summary_by_meeting_command":
+					return { success: true, data: null, error: null };
+				case "update_meeting_command":
+					return {
+						success: true,
+						data: { ...mockMeeting, title: "Updated Meeting Title" },
+						error: null,
+					};
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<MeetingDetailView meetingId={1} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Product Planning Meeting")).toBeInTheDocument();
+		});
+
+		// Find edit button by title attribute or class
+		const editButton = screen.getByTitle("Edit title");
+		await userEvent.click(editButton);
+
+		const input = screen.getByRole("textbox");
+		await userEvent.clear(input);
+		await userEvent.type(input, "Updated Meeting Title");
+
+		// Save button shows checkmark symbol
+		const saveButton = document.querySelector(".title-edit-button.save");
+		if (!saveButton) throw new Error("Save button not found");
+		await userEvent.click(saveButton);
+
+		await waitFor(() => {
+			expect(screen.getByText("Updated Meeting Title")).toBeInTheDocument();
+		});
+	});
+
+	it("cancels title edit when cancel is clicked", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "get_meeting_command":
+					return { success: true, data: mockMeeting, error: null };
+				case "get_transcript_by_meeting_command":
+					return { success: true, data: null, error: null };
+				case "get_summary_by_meeting_command":
+					return { success: true, data: null, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<MeetingDetailView meetingId={1} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Product Planning Meeting")).toBeInTheDocument();
+		});
+
+		// Find edit button by title attribute or class
+		const editButton = screen.getByTitle("Edit title");
+		await userEvent.click(editButton);
+
+		const input = screen.getByRole("textbox");
+		await userEvent.type(input, " Some Extra Text");
+
+		// Cancel button shows X symbol
+		const cancelButton = document.querySelector(".title-edit-button.cancel");
+		if (!cancelButton) throw new Error("Cancel button not found");
+		await userEvent.click(cancelButton);
+
+		// Original title should still be displayed
+		expect(screen.getByText("Product Planning Meeting")).toBeInTheDocument();
+	});
+
+	it("copies transcript to clipboard", async () => {
+		const mockClipboard = {
+			writeText: vi.fn().mockResolvedValue(undefined),
+		};
+		Object.assign(navigator, { clipboard: mockClipboard });
+
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "get_meeting_command":
+					return { success: true, data: mockMeeting, error: null };
+				case "get_transcript_by_meeting_command":
+					return { success: true, data: mockTranscript, error: null };
+				case "get_summary_by_meeting_command":
+					return { success: true, data: null, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<MeetingDetailView meetingId={1} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Transcript")).toBeInTheDocument();
+		});
+
+		// Find the copy button in the transcript card (the one showing "📋 Copy")
+		const transcriptCard = screen.getByText("Transcript").closest(".meeting-detail-card");
+		const copyButton = transcriptCard?.querySelector(".copy-button");
+		if (!copyButton) throw new Error("Copy button not found");
+		await userEvent.click(copyButton);
+
+		expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mockTranscript.content);
+	});
+
+	it("copies summary to clipboard", async () => {
+		const mockClipboard = {
+			writeText: vi.fn().mockResolvedValue(undefined),
+		};
+		Object.assign(navigator, { clipboard: mockClipboard });
+
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "get_meeting_command":
+					return { success: true, data: mockMeeting, error: null };
+				case "get_transcript_by_meeting_command":
+					return { success: true, data: null, error: null };
+				case "get_summary_by_meeting_command":
+					return { success: true, data: mockSummary, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<MeetingDetailView meetingId={1} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Summary")).toBeInTheDocument();
+		});
+
+		// Find the copy button in the summary card (the one showing "📋 Copy")
+		const summaryCard = screen.getByText("Summary").closest(".meeting-detail-card");
+		const copyButton = summaryCard?.querySelector(".copy-button");
+		if (!copyButton) throw new Error("Copy button not found");
+		await userEvent.click(copyButton);
+
+		expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+			expect.stringContaining("Key Points:"),
+		);
+	});
+
+	it("shows no content message when transcript and summary are missing", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "get_meeting_command":
+					return { success: true, data: mockMeeting, error: null };
+				case "get_transcript_by_meeting_command":
+					return { success: true, data: null, error: null };
+				case "get_summary_by_meeting_command":
+					return { success: true, data: null, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<MeetingDetailView meetingId={1} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Product Planning Meeting")).toBeInTheDocument();
+		});
+
+		expect(screen.getByText("No transcript available for this meeting.")).toBeInTheDocument();
+		expect(screen.getByText("No summary generated for this meeting.")).toBeInTheDocument();
+	});
+
+	it("parses and displays key points from summary", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "get_meeting_command":
+					return { success: true, data: mockMeeting, error: null };
+				case "get_transcript_by_meeting_command":
+					return { success: true, data: null, error: null };
+				case "get_summary_by_meeting_command":
+					return { success: true, data: mockSummary, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<MeetingDetailView meetingId={1} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Key Points")).toBeInTheDocument();
+		});
+
+		expect(screen.getByText("Discussed Q2 roadmap")).toBeInTheDocument();
+		expect(screen.getByText("Mobile app is top priority")).toBeInTheDocument();
+	});
+
+	it("parses and displays decisions from summary", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "get_meeting_command":
+					return { success: true, data: mockMeeting, error: null };
+				case "get_transcript_by_meeting_command":
+					return { success: true, data: null, error: null };
+				case "get_summary_by_meeting_command":
+					return { success: true, data: mockSummary, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<MeetingDetailView meetingId={1} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Decisions")).toBeInTheDocument();
+		});
+
+		expect(screen.getByText("Approved Q2 plan")).toBeInTheDocument();
+		expect(screen.getByText("Hired 2 more developers")).toBeInTheDocument();
+	});
+
+	it("parses and displays action items from summary", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "get_meeting_command":
+					return { success: true, data: mockMeeting, error: null };
+				case "get_transcript_by_meeting_command":
+					return { success: true, data: null, error: null };
+				case "get_summary_by_meeting_command":
+					return { success: true, data: mockSummary, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<MeetingDetailView meetingId={1} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Action Items")).toBeInTheDocument();
+		});
+
+		expect(screen.getByText("John: Prepare design mockups")).toBeInTheDocument();
+		expect(screen.getByText("Sarah: Schedule follow-up")).toBeInTheDocument();
+	});
+});

--- a/src/components/__tests__/MeetingDetailView.test.tsx
+++ b/src/components/__tests__/MeetingDetailView.test.tsx
@@ -4,11 +4,6 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MeetingDetailView } from "../MeetingDetailView";
 
-// Mock Tauri API
-vi.mock("@tauri-apps/api/core", () => ({
-	invoke: vi.fn(),
-}));
-
 const mockMeeting = {
 	id: 1,
 	title: "Product Planning Meeting",
@@ -175,9 +170,8 @@ describe("MeetingDetailView", () => {
 		await userEvent.clear(input);
 		await userEvent.type(input, "Updated Meeting Title");
 
-		// Save button shows checkmark symbol
-		const saveButton = document.querySelector(".title-edit-button.save");
-		if (!saveButton) throw new Error("Save button not found");
+		// Save button
+		const saveButton = screen.getByRole("button", { name: /save title/i });
 		await userEvent.click(saveButton);
 
 		await waitFor(() => {
@@ -212,9 +206,8 @@ describe("MeetingDetailView", () => {
 		const input = screen.getByRole("textbox");
 		await userEvent.type(input, " Some Extra Text");
 
-		// Cancel button shows X symbol
-		const cancelButton = document.querySelector(".title-edit-button.cancel");
-		if (!cancelButton) throw new Error("Cancel button not found");
+		// Cancel button
+		const cancelButton = screen.getByRole("button", { name: /cancel editing/i });
 		await userEvent.click(cancelButton);
 
 		// Original title should still be displayed
@@ -246,10 +239,8 @@ describe("MeetingDetailView", () => {
 			expect(screen.getByText("Transcript")).toBeInTheDocument();
 		});
 
-		// Find the copy button in the transcript card (the one showing "📋 Copy")
-		const transcriptCard = screen.getByText("Transcript").closest(".meeting-detail-card");
-		const copyButton = transcriptCard?.querySelector(".copy-button");
-		if (!copyButton) throw new Error("Copy button not found");
+		// Find the copy button for transcript
+		const copyButton = screen.getByRole("button", { name: /copy transcript/i });
 		await userEvent.click(copyButton);
 
 		expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mockTranscript.content);
@@ -280,10 +271,8 @@ describe("MeetingDetailView", () => {
 			expect(screen.getByText("Summary")).toBeInTheDocument();
 		});
 
-		// Find the copy button in the summary card (the one showing "📋 Copy")
-		const summaryCard = screen.getByText("Summary").closest(".meeting-detail-card");
-		const copyButton = summaryCard?.querySelector(".copy-button");
-		if (!copyButton) throw new Error("Copy button not found");
+		// Find the copy button for summary
+		const copyButton = screen.getByRole("button", { name: /copy summary/i });
 		await userEvent.click(copyButton);
 
 		expect(navigator.clipboard.writeText).toHaveBeenCalledWith(

--- a/src/components/__tests__/RecordView.test.tsx
+++ b/src/components/__tests__/RecordView.test.tsx
@@ -1,0 +1,256 @@
+import { invoke } from "@tauri-apps/api/core";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RecordView } from "../RecordView";
+
+// Mock Tauri API
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+	listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+describe("RecordView", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("shows idle state initially", () => {
+		render(<RecordView />);
+
+		expect(screen.getByText("Ready to record")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /start recording/i })).toBeInTheDocument();
+	});
+
+	it("starts recording when button is clicked", async () => {
+		vi.mocked(invoke).mockResolvedValue({
+			success: true,
+			data: true,
+			error: null,
+		});
+
+		render(<RecordView />);
+
+		const startButton = screen.getByRole("button", { name: /start recording/i });
+		await userEvent.click(startButton);
+
+		await waitFor(() => {
+			expect(screen.getByText("Recording in progress...")).toBeInTheDocument();
+		});
+
+		expect(screen.getByRole("button", { name: /stop recording/i })).toBeInTheDocument();
+	});
+
+	it("stops recording and shows title modal", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			if (command === "start_recording_command") {
+				return { success: true, data: true, error: null };
+			}
+			if (command === "stop_recording_command") {
+				return {
+					success: true,
+					data: {
+						file_path: "/path/to/recording.wav",
+						duration_seconds: 60,
+						used_system_audio: true,
+					},
+					error: null,
+				};
+			}
+			return { success: false, data: null, error: "Unknown command" };
+		});
+
+		render(<RecordView />);
+
+		// Start recording
+		const startButton = screen.getByRole("button", { name: /start recording/i });
+		await userEvent.click(startButton);
+
+		await waitFor(() => {
+			expect(screen.getByText("Recording in progress...")).toBeInTheDocument();
+		});
+
+		// Stop recording
+		const stopButton = screen.getByRole("button", { name: /stop recording/i });
+		await userEvent.click(stopButton);
+
+		await waitFor(() => {
+			expect(screen.getByText("Save Recording")).toBeInTheDocument();
+		});
+
+		expect(screen.getByLabelText("Meeting Title")).toBeInTheDocument();
+		expect(screen.getByText("Duration: 01:00")).toBeInTheDocument();
+		expect(screen.getByText("System audio included")).toBeInTheDocument();
+	});
+
+	it("tests microphone and shows result", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			if (command === "test_microphone_command") {
+				return { success: true, data: 0.05, error: null }; // Good audio level
+			}
+			return { success: false, data: null, error: "Unknown command" };
+		});
+
+		render(<RecordView />);
+
+		const testButton = screen.getByRole("button", { name: /test microphone/i });
+		await userEvent.click(testButton);
+
+		await waitFor(() => {
+			expect(screen.getByText(/microphone is working/i)).toBeInTheDocument();
+		});
+	});
+
+	it("shows microphone silent warning", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			if (command === "test_microphone_command") {
+				return { success: true, data: 0.001, error: null }; // Low audio level
+			}
+			return { success: false, data: null, error: "Unknown command" };
+		});
+
+		render(<RecordView onNavigateToSettings={vi.fn()} />);
+
+		const testButton = screen.getByRole("button", { name: /test microphone/i });
+		await userEvent.click(testButton);
+
+		await waitFor(() => {
+			expect(screen.getByText(/no audio detected/i)).toBeInTheDocument();
+		});
+	});
+
+	it("saves meeting and processes to transcription complete", async () => {
+		const onMeetingCreated = vi.fn();
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			if (command === "start_recording_command") {
+				return { success: true, data: true, error: null };
+			}
+			if (command === "stop_recording_command") {
+				return {
+					success: true,
+					data: {
+						file_path: "/path/to/recording.wav",
+						duration_seconds: 60,
+						used_system_audio: false,
+					},
+					error: null,
+				};
+			}
+			if (command === "create_meeting_command") {
+				return {
+					success: true,
+					data: {
+						id: 1,
+						title: "Test Meeting",
+						date: "2026-04-20T10:00:00Z",
+						duration_seconds: 60,
+						audio_path: "/path/to/recording.wav",
+						created_at: "2026-04-20T10:00:00Z",
+					},
+					error: null,
+				};
+			}
+			if (command === "transcribe_audio_command") {
+				return {
+					success: true,
+					data: {
+						transcript_id: 1,
+						text: "This is the transcript",
+						duration_seconds: 5,
+					},
+					error: null,
+				};
+			}
+			return { success: false, data: null, error: "Unknown command" };
+		});
+
+		render(<RecordView onMeetingCreated={onMeetingCreated} />);
+
+		// Start and stop recording
+		await userEvent.click(screen.getByRole("button", { name: /start recording/i }));
+		await waitFor(() => {
+			expect(screen.getByText("Recording in progress...")).toBeInTheDocument();
+		});
+
+		await userEvent.click(screen.getByRole("button", { name: /stop recording/i }));
+		await waitFor(() => {
+			expect(screen.getByText("Save Recording")).toBeInTheDocument();
+		});
+
+		// Enter meeting title
+		const titleInput = screen.getByLabelText("Meeting Title");
+		await userEvent.clear(titleInput);
+		await userEvent.type(titleInput, "Test Meeting");
+
+		// Save meeting
+		const saveButton = screen.getByRole("button", { name: /save meeting/i });
+		await userEvent.click(saveButton);
+
+		// Since API call is fast, we may see either transcribing or complete state
+		await waitFor(() => {
+			expect(screen.getByText("Processing Meeting")).toBeInTheDocument();
+		});
+	});
+
+	it("shows error when recording fails to start", async () => {
+		vi.mocked(invoke).mockResolvedValue({
+			success: false,
+			data: null,
+			error: "Microphone permission denied",
+		});
+
+		render(<RecordView />);
+
+		const startButton = screen.getByRole("button", { name: /start recording/i });
+		await userEvent.click(startButton);
+
+		await waitFor(() => {
+			expect(screen.getByText("Microphone permission denied")).toBeInTheDocument();
+		});
+	});
+
+	it("allows discarding recording", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			if (command === "start_recording_command") {
+				return { success: true, data: true, error: null };
+			}
+			if (command === "stop_recording_command") {
+				return {
+					success: true,
+					data: {
+						file_path: "/path/to/recording.wav",
+						duration_seconds: 30,
+						used_system_audio: false,
+					},
+					error: null,
+				};
+			}
+			return { success: false, data: null, error: "Unknown command" };
+		});
+
+		render(<RecordView />);
+
+		// Start and stop recording
+		await userEvent.click(screen.getByRole("button", { name: /start recording/i }));
+		await waitFor(() => {
+			expect(screen.getByText("Recording in progress...")).toBeInTheDocument();
+		});
+
+		await userEvent.click(screen.getByRole("button", { name: /stop recording/i }));
+		await waitFor(() => {
+			expect(screen.getByText("Save Recording")).toBeInTheDocument();
+		});
+
+		// Click discard
+		const discardButton = screen.getByRole("button", { name: /discard/i });
+		await userEvent.click(discardButton);
+
+		// Should return to idle state
+		await waitFor(() => {
+			expect(screen.getByText("Ready to record")).toBeInTheDocument();
+		});
+	});
+});

--- a/src/components/__tests__/RecordView.test.tsx
+++ b/src/components/__tests__/RecordView.test.tsx
@@ -4,15 +4,6 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RecordView } from "../RecordView";
 
-// Mock Tauri API
-vi.mock("@tauri-apps/api/core", () => ({
-	invoke: vi.fn(),
-}));
-
-vi.mock("@tauri-apps/api/event", () => ({
-	listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
 describe("RecordView", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/src/components/__tests__/SettingsView.test.tsx
+++ b/src/components/__tests__/SettingsView.test.tsx
@@ -1,0 +1,333 @@
+import { invoke } from "@tauri-apps/api/core";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SettingsView } from "../SettingsView";
+
+// Mock Tauri API
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+	listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+const mockAudioDevices = [
+	{ id: "device1", name: "Built-in Microphone" },
+	{ id: "device2", name: "USB Microphone" },
+];
+
+const mockWhisperModels = [
+	{
+		size: "tiny",
+		filename: "ggml-tiny.bin",
+		expected_size: 75000000,
+		is_downloaded: true,
+		actual_size: 75000000,
+	},
+	{
+		size: "small",
+		filename: "ggml-small.bin",
+		expected_size: 466000000,
+		is_downloaded: false,
+		actual_size: null,
+	},
+];
+
+describe("SettingsView", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("shows loading state initially", () => {
+		vi.mocked(invoke).mockImplementation(() => new Promise(() => {}));
+
+		render(<SettingsView />);
+
+		expect(screen.getByText("Loading settings...")).toBeInTheDocument();
+	});
+
+	it("displays settings after loading", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "list_audio_devices_command":
+					return { success: true, data: mockAudioDevices, error: null };
+				case "list_whisper_models_command":
+					return { success: true, data: mockWhisperModels, error: null };
+				case "get_setting_command":
+					return { success: true, data: "", error: null };
+				case "check_ollama_status_command":
+					return {
+						success: true,
+						data: { available: true, url: "http://localhost:11434" },
+						error: null,
+					};
+				case "check_blackhole_status_command":
+					return {
+						success: true,
+						data: { installed: true, device_name: "BlackHole 2ch" },
+						error: null,
+					};
+				case "check_homebrew_status_command":
+					return { success: true, data: true, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<SettingsView />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Settings")).toBeInTheDocument();
+		});
+
+		expect(screen.getByText("Audio")).toBeInTheDocument();
+		expect(screen.getByText("Transcription Model")).toBeInTheDocument();
+		expect(screen.getByText("Summary Generation")).toBeInTheDocument();
+	});
+
+	it("shows BlackHole installed status", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "list_audio_devices_command":
+					return { success: true, data: mockAudioDevices, error: null };
+				case "list_whisper_models_command":
+					return { success: true, data: mockWhisperModels, error: null };
+				case "get_setting_command":
+					return { success: true, data: "", error: null };
+				case "check_ollama_status_command":
+					return {
+						success: true,
+						data: { available: true, url: "http://localhost:11434" },
+						error: null,
+					};
+				case "check_blackhole_status_command":
+					return {
+						success: true,
+						data: { installed: true, device_name: "BlackHole 2ch" },
+						error: null,
+					};
+				case "check_homebrew_status_command":
+					return { success: true, data: true, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<SettingsView />);
+
+		await waitFor(() => {
+			expect(screen.getByText(/BlackHole installed/i)).toBeInTheDocument();
+		});
+	});
+
+	it("shows BlackHole not installed warning", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "list_audio_devices_command":
+					return { success: true, data: mockAudioDevices, error: null };
+				case "list_whisper_models_command":
+					return { success: true, data: mockWhisperModels, error: null };
+				case "get_setting_command":
+					return { success: true, data: "", error: null };
+				case "check_ollama_status_command":
+					return {
+						success: true,
+						data: { available: true, url: "http://localhost:11434" },
+						error: null,
+					};
+				case "check_blackhole_status_command":
+					return { success: true, data: { installed: false, device_name: null }, error: null };
+				case "check_homebrew_status_command":
+					return { success: true, data: false, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<SettingsView />);
+
+		await waitFor(() => {
+			expect(screen.getByText(/BlackHole not installed/i)).toBeInTheDocument();
+		});
+
+		expect(screen.getByRole("button", { name: /download installer/i })).toBeInTheDocument();
+	});
+
+	it("shows downloaded and not downloaded model statuses", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "list_audio_devices_command":
+					return { success: true, data: mockAudioDevices, error: null };
+				case "list_whisper_models_command":
+					return { success: true, data: mockWhisperModels, error: null };
+				case "get_setting_command":
+					return { success: true, data: "", error: null };
+				case "check_ollama_status_command":
+					return {
+						success: true,
+						data: { available: true, url: "http://localhost:11434" },
+						error: null,
+					};
+				case "check_blackhole_status_command":
+					return {
+						success: true,
+						data: { installed: true, device_name: "BlackHole 2ch" },
+						error: null,
+					};
+				case "check_homebrew_status_command":
+					return { success: true, data: true, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<SettingsView />);
+
+		await waitFor(() => {
+			expect(screen.getByText("tiny")).toBeInTheDocument();
+		});
+
+		expect(screen.getByText(/✓ Downloaded/)).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /download/i })).toBeInTheDocument();
+	});
+
+	it("saves setting when audio device is changed", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string, args?: unknown) => {
+			switch (command) {
+				case "list_audio_devices_command":
+					return { success: true, data: mockAudioDevices, error: null };
+				case "list_whisper_models_command":
+					return { success: true, data: mockWhisperModels, error: null };
+				case "get_setting_command": {
+					const req = args as { request: { key: string } };
+					if (req?.request?.key === "audio_device") {
+						return { success: true, data: "device1", error: null };
+					}
+					return { success: true, data: "", error: null };
+				}
+				case "set_setting_command":
+					return { success: true, data: true, error: null };
+				case "check_ollama_status_command":
+					return {
+						success: true,
+						data: { available: true, url: "http://localhost:11434" },
+						error: null,
+					};
+				case "check_blackhole_status_command":
+					return {
+						success: true,
+						data: { installed: true, device_name: "BlackHole 2ch" },
+						error: null,
+					};
+				case "check_homebrew_status_command":
+					return { success: true, data: true, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<SettingsView />);
+
+		await waitFor(() => {
+			expect(screen.getByLabelText("Audio Input Device")).toBeInTheDocument();
+		});
+
+		const select = screen.getByLabelText("Audio Input Device");
+		await userEvent.selectOptions(select, "device2");
+
+		await waitFor(() => {
+			expect(screen.getByText("Settings saved successfully")).toBeInTheDocument();
+		});
+	});
+
+	it("switches to API provider and shows API settings", async () => {
+		vi.mocked(invoke).mockImplementation(async (command: string, args?: unknown) => {
+			switch (command) {
+				case "list_audio_devices_command":
+					return { success: true, data: mockAudioDevices, error: null };
+				case "list_whisper_models_command":
+					return { success: true, data: mockWhisperModels, error: null };
+				case "get_setting_command": {
+					const req = args as { request: { key: string } };
+					if (req?.request?.key === "llm_provider") {
+						return { success: true, data: "api", error: null };
+					}
+					return { success: true, data: "", error: null };
+				}
+				case "set_setting_command":
+					return { success: true, data: true, error: null };
+				case "check_ollama_status_command":
+					return {
+						success: true,
+						data: { available: true, url: "http://localhost:11434" },
+						error: null,
+					};
+				case "check_blackhole_status_command":
+					return {
+						success: true,
+						data: { installed: true, device_name: "BlackHole 2ch" },
+						error: null,
+					};
+				case "check_homebrew_status_command":
+					return { success: true, data: true, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<SettingsView />);
+
+		await waitFor(() => {
+			expect(screen.getByLabelText("API Key")).toBeInTheDocument();
+		});
+
+		expect(screen.getByText(/Data will leave your device/i)).toBeInTheDocument();
+	});
+
+	it("shows prompt when no models are downloaded", async () => {
+		const emptyModels = [
+			{
+				size: "tiny",
+				filename: "ggml-tiny.bin",
+				expected_size: 75000000,
+				is_downloaded: false,
+				actual_size: null,
+			},
+		];
+
+		vi.mocked(invoke).mockImplementation(async (command: string) => {
+			switch (command) {
+				case "list_audio_devices_command":
+					return { success: true, data: mockAudioDevices, error: null };
+				case "list_whisper_models_command":
+					return { success: true, data: emptyModels, error: null };
+				case "get_setting_command":
+					return { success: true, data: "", error: null };
+				case "check_ollama_status_command":
+					return {
+						success: true,
+						data: { available: true, url: "http://localhost:11434" },
+						error: null,
+					};
+				case "check_blackhole_status_command":
+					return {
+						success: true,
+						data: { installed: true, device_name: "BlackHole 2ch" },
+						error: null,
+					};
+				case "check_homebrew_status_command":
+					return { success: true, data: true, error: null };
+				default:
+					return { success: false, data: null, error: "Unknown command" };
+			}
+		});
+
+		render(<SettingsView />);
+
+		await waitFor(() => {
+			expect(screen.getByText(/No model downloaded yet/i)).toBeInTheDocument();
+		});
+	});
+});

--- a/src/components/__tests__/SettingsView.test.tsx
+++ b/src/components/__tests__/SettingsView.test.tsx
@@ -4,15 +4,6 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SettingsView } from "../SettingsView";
 
-// Mock Tauri API
-vi.mock("@tauri-apps/api/core", () => ({
-	invoke: vi.fn(),
-}));
-
-vi.mock("@tauri-apps/api/event", () => ({
-	listen: vi.fn().mockResolvedValue(() => {}),
-}));
-
 const mockAudioDevices = [
 	{ id: "device1", name: "Built-in Microphone" },
 	{ id: "device2", name: "USB Microphone" },
@@ -35,6 +26,66 @@ const mockWhisperModels = [
 	},
 ];
 
+// Helper to create mock invoke implementations with customizable overrides
+function createMockInvoke(
+	overrides: {
+		whisperModels?: typeof mockWhisperModels;
+		blackholeInstalled?: boolean;
+		homebrewInstalled?: boolean;
+		llmProvider?: string | null;
+		settingValues?: Record<string, string>;
+		setSettingReturns?: boolean;
+	} = {},
+) {
+	return async (command: string, args?: unknown) => {
+		const whisperModels = overrides.whisperModels ?? mockWhisperModels;
+		const blackholeInstalled = overrides.blackholeInstalled ?? true;
+		const homebrewInstalled = overrides.homebrewInstalled ?? true;
+		const llmProvider = overrides.llmProvider ?? null;
+		const settingValues = overrides.settingValues ?? {};
+		const setSettingReturns = overrides.setSettingReturns ?? true;
+
+		switch (command) {
+			case "list_audio_devices_command":
+				return { success: true, data: mockAudioDevices, error: null };
+			case "list_whisper_models_command":
+				return { success: true, data: whisperModels, error: null };
+			case "get_setting_command": {
+				const req = args as { request: { key: string } } | undefined;
+				const key = req?.request?.key;
+				if (key && settingValues[key] !== undefined) {
+					return { success: true, data: settingValues[key], error: null };
+				}
+				if (key === "llm_provider" && llmProvider !== null) {
+					return { success: true, data: llmProvider, error: null };
+				}
+				return { success: true, data: "", error: null };
+			}
+			case "set_setting_command":
+				return { success: true, data: setSettingReturns, error: null };
+			case "check_ollama_status_command":
+				return {
+					success: true,
+					data: { available: true, url: "http://localhost:11434" },
+					error: null,
+				};
+			case "check_blackhole_status_command":
+				return {
+					success: true,
+					data: {
+						installed: blackholeInstalled,
+						device_name: blackholeInstalled ? "BlackHole 2ch" : null,
+					},
+					error: null,
+				};
+			case "check_homebrew_status_command":
+				return { success: true, data: homebrewInstalled, error: null };
+			default:
+				return { success: false, data: null, error: "Unknown command" };
+		}
+	};
+}
+
 describe("SettingsView", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -49,32 +100,7 @@ describe("SettingsView", () => {
 	});
 
 	it("displays settings after loading", async () => {
-		vi.mocked(invoke).mockImplementation(async (command: string) => {
-			switch (command) {
-				case "list_audio_devices_command":
-					return { success: true, data: mockAudioDevices, error: null };
-				case "list_whisper_models_command":
-					return { success: true, data: mockWhisperModels, error: null };
-				case "get_setting_command":
-					return { success: true, data: "", error: null };
-				case "check_ollama_status_command":
-					return {
-						success: true,
-						data: { available: true, url: "http://localhost:11434" },
-						error: null,
-					};
-				case "check_blackhole_status_command":
-					return {
-						success: true,
-						data: { installed: true, device_name: "BlackHole 2ch" },
-						error: null,
-					};
-				case "check_homebrew_status_command":
-					return { success: true, data: true, error: null };
-				default:
-					return { success: false, data: null, error: "Unknown command" };
-			}
-		});
+		vi.mocked(invoke).mockImplementation(createMockInvoke());
 
 		render(<SettingsView />);
 
@@ -88,32 +114,7 @@ describe("SettingsView", () => {
 	});
 
 	it("shows BlackHole installed status", async () => {
-		vi.mocked(invoke).mockImplementation(async (command: string) => {
-			switch (command) {
-				case "list_audio_devices_command":
-					return { success: true, data: mockAudioDevices, error: null };
-				case "list_whisper_models_command":
-					return { success: true, data: mockWhisperModels, error: null };
-				case "get_setting_command":
-					return { success: true, data: "", error: null };
-				case "check_ollama_status_command":
-					return {
-						success: true,
-						data: { available: true, url: "http://localhost:11434" },
-						error: null,
-					};
-				case "check_blackhole_status_command":
-					return {
-						success: true,
-						data: { installed: true, device_name: "BlackHole 2ch" },
-						error: null,
-					};
-				case "check_homebrew_status_command":
-					return { success: true, data: true, error: null };
-				default:
-					return { success: false, data: null, error: "Unknown command" };
-			}
-		});
+		vi.mocked(invoke).mockImplementation(createMockInvoke({ blackholeInstalled: true }));
 
 		render(<SettingsView />);
 
@@ -123,28 +124,9 @@ describe("SettingsView", () => {
 	});
 
 	it("shows BlackHole not installed warning", async () => {
-		vi.mocked(invoke).mockImplementation(async (command: string) => {
-			switch (command) {
-				case "list_audio_devices_command":
-					return { success: true, data: mockAudioDevices, error: null };
-				case "list_whisper_models_command":
-					return { success: true, data: mockWhisperModels, error: null };
-				case "get_setting_command":
-					return { success: true, data: "", error: null };
-				case "check_ollama_status_command":
-					return {
-						success: true,
-						data: { available: true, url: "http://localhost:11434" },
-						error: null,
-					};
-				case "check_blackhole_status_command":
-					return { success: true, data: { installed: false, device_name: null }, error: null };
-				case "check_homebrew_status_command":
-					return { success: true, data: false, error: null };
-				default:
-					return { success: false, data: null, error: "Unknown command" };
-			}
-		});
+		vi.mocked(invoke).mockImplementation(
+			createMockInvoke({ blackholeInstalled: false, homebrewInstalled: false }),
+		);
 
 		render(<SettingsView />);
 
@@ -156,32 +138,7 @@ describe("SettingsView", () => {
 	});
 
 	it("shows downloaded and not downloaded model statuses", async () => {
-		vi.mocked(invoke).mockImplementation(async (command: string) => {
-			switch (command) {
-				case "list_audio_devices_command":
-					return { success: true, data: mockAudioDevices, error: null };
-				case "list_whisper_models_command":
-					return { success: true, data: mockWhisperModels, error: null };
-				case "get_setting_command":
-					return { success: true, data: "", error: null };
-				case "check_ollama_status_command":
-					return {
-						success: true,
-						data: { available: true, url: "http://localhost:11434" },
-						error: null,
-					};
-				case "check_blackhole_status_command":
-					return {
-						success: true,
-						data: { installed: true, device_name: "BlackHole 2ch" },
-						error: null,
-					};
-				case "check_homebrew_status_command":
-					return { success: true, data: true, error: null };
-				default:
-					return { success: false, data: null, error: "Unknown command" };
-			}
-		});
+		vi.mocked(invoke).mockImplementation(createMockInvoke());
 
 		render(<SettingsView />);
 
@@ -194,39 +151,9 @@ describe("SettingsView", () => {
 	});
 
 	it("saves setting when audio device is changed", async () => {
-		vi.mocked(invoke).mockImplementation(async (command: string, args?: unknown) => {
-			switch (command) {
-				case "list_audio_devices_command":
-					return { success: true, data: mockAudioDevices, error: null };
-				case "list_whisper_models_command":
-					return { success: true, data: mockWhisperModels, error: null };
-				case "get_setting_command": {
-					const req = args as { request: { key: string } };
-					if (req?.request?.key === "audio_device") {
-						return { success: true, data: "device1", error: null };
-					}
-					return { success: true, data: "", error: null };
-				}
-				case "set_setting_command":
-					return { success: true, data: true, error: null };
-				case "check_ollama_status_command":
-					return {
-						success: true,
-						data: { available: true, url: "http://localhost:11434" },
-						error: null,
-					};
-				case "check_blackhole_status_command":
-					return {
-						success: true,
-						data: { installed: true, device_name: "BlackHole 2ch" },
-						error: null,
-					};
-				case "check_homebrew_status_command":
-					return { success: true, data: true, error: null };
-				default:
-					return { success: false, data: null, error: "Unknown command" };
-			}
-		});
+		vi.mocked(invoke).mockImplementation(
+			createMockInvoke({ settingValues: { audio_device: "device1" } }),
+		);
 
 		render(<SettingsView />);
 
@@ -243,39 +170,7 @@ describe("SettingsView", () => {
 	});
 
 	it("switches to API provider and shows API settings", async () => {
-		vi.mocked(invoke).mockImplementation(async (command: string, args?: unknown) => {
-			switch (command) {
-				case "list_audio_devices_command":
-					return { success: true, data: mockAudioDevices, error: null };
-				case "list_whisper_models_command":
-					return { success: true, data: mockWhisperModels, error: null };
-				case "get_setting_command": {
-					const req = args as { request: { key: string } };
-					if (req?.request?.key === "llm_provider") {
-						return { success: true, data: "api", error: null };
-					}
-					return { success: true, data: "", error: null };
-				}
-				case "set_setting_command":
-					return { success: true, data: true, error: null };
-				case "check_ollama_status_command":
-					return {
-						success: true,
-						data: { available: true, url: "http://localhost:11434" },
-						error: null,
-					};
-				case "check_blackhole_status_command":
-					return {
-						success: true,
-						data: { installed: true, device_name: "BlackHole 2ch" },
-						error: null,
-					};
-				case "check_homebrew_status_command":
-					return { success: true, data: true, error: null };
-				default:
-					return { success: false, data: null, error: "Unknown command" };
-			}
-		});
+		vi.mocked(invoke).mockImplementation(createMockInvoke({ llmProvider: "api" }));
 
 		render(<SettingsView />);
 
@@ -297,32 +192,7 @@ describe("SettingsView", () => {
 			},
 		];
 
-		vi.mocked(invoke).mockImplementation(async (command: string) => {
-			switch (command) {
-				case "list_audio_devices_command":
-					return { success: true, data: mockAudioDevices, error: null };
-				case "list_whisper_models_command":
-					return { success: true, data: emptyModels, error: null };
-				case "get_setting_command":
-					return { success: true, data: "", error: null };
-				case "check_ollama_status_command":
-					return {
-						success: true,
-						data: { available: true, url: "http://localhost:11434" },
-						error: null,
-					};
-				case "check_blackhole_status_command":
-					return {
-						success: true,
-						data: { installed: true, device_name: "BlackHole 2ch" },
-						error: null,
-					};
-				case "check_homebrew_status_command":
-					return { success: true, data: true, error: null };
-				default:
-					return { success: false, data: null, error: "Unknown command" };
-			}
-		});
+		vi.mocked(invoke).mockImplementation(createMockInvoke({ whisperModels: emptyModels }));
 
 		render(<SettingsView />);
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,17 @@
+import "@testing-library/jest-dom";
+import { beforeEach, vi } from "vitest";
+
+// Mock Tauri API
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+	listen: vi.fn(),
+	emit: vi.fn(),
+}));
+
+// Reset all mocks before each test
+beforeEach(() => {
+	vi.clearAllMocks();
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -11,7 +11,8 @@ vi.mock("@tauri-apps/api/event", () => ({
 	emit: vi.fn(),
 }));
 
-// Reset all mocks before each test
+// Reset all mocks before each test to ensure clean state between tests
+// Errors during mock cleanup are intentionally ignored - Vitest handles these
 beforeEach(() => {
 	vi.clearAllMocks();
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	plugins: [react()],
+	test: {
+		globals: true,
+		environment: "jsdom",
+		setupFiles: ["./src/test/setup.ts"],
+		include: ["src/**/*.{test,spec}.{ts,tsx}"],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "json", "html"],
+			include: ["src/components/**/*.tsx"],
+			exclude: ["src/**/*.d.ts", "src/test/**/*"],
+		},
+	},
+});


### PR DESCRIPTION
## Summary
- Add 43 frontend component tests with Vitest + React Testing Library
- Add 23 Rust integration tests for database operations and end-to-end flows
- Closes #9 and #10

## Frontend Tests
- ErrorBoundary: Error catching and fallback UI
- HistoryView: Loading, empty state, meeting list, delete flow
- MeetingDetailView: Display, title editing, copy functionality
- RecordView: Recording flow, microphone test, processing states
- SettingsView: Device selection, BlackHole status, model downloads

## Backend Tests
- Database CRUD: Meetings, transcripts, summaries, settings
- End-to-end flows: Full meeting lifecycle
- Test utilities: Temporary SQLite databases with automatic cleanup

## Test Plan
- [x] `bun test:run` - All 43 frontend tests pass
- [x] `cargo test` - All 23 Rust tests pass
- [x] `just check` - TypeScript and Rust typecheck pass
- [x] `just lint` - Biome and Clippy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)